### PR TITLE
feat(npm-v9): bump version of dependency extractor

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -34,8 +34,6 @@
 - [ ] `npm run test` passes with this change
 - [ ] This pull request links relevant issues as `Fixes #0000`
 - [ ] There are new or updated unit tests validating the change
-- [ ] Added documentation inside `www/docs/main` folder.
-- [ ] Included new files inside `index.doc.ts`.
 - [ ] The new commits follow conventions outlined in the [conventional commit spec](https://www.conventionalcommits.org/en/v1.0.0/)
 
 <!--

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -8,7 +8,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [ 12.x, 14.x, 16.x, 18.x ]
+        node-version: [ 14.x, 16.x, 18.x ]
 
     steps:
       - uses: actions/checkout@v3

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,1 @@
+nodejs lts-fermium

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@h4ad/node-modules-packer",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@h4ad/node-modules-packer",
-      "version": "1.2.1",
+      "version": "1.2.2",
       "license": "MIT",
       "dependencies": {
-        "@h4ad/dependency-extractor": "^1.0.0",
+        "@h4ad/dependency-extractor": "1.1.0",
         "@oclif/core": "^1",
         "@oclif/plugin-autocomplete": "^1.3.0",
         "@oclif/plugin-commands": "^2.2.0",
@@ -707,11 +707,11 @@
       "dev": true
     },
     "node_modules/@h4ad/dependency-extractor": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@h4ad/dependency-extractor/-/dependency-extractor-1.0.0.tgz",
-      "integrity": "sha512-2DbOyTWjxkS3F8ZBKfD1FwrKxsAnH9mOdRe9FD01Eldtx/DOwuGbvuSDh2BoAfc4FhdElf3a5RArzZExVfRMXA==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@h4ad/dependency-extractor/-/dependency-extractor-1.1.0.tgz",
+      "integrity": "sha512-kJdeQN4bKsWy5b5bAx7MW8q1yl+ZQmljF+HEateOZ5/B/MRyZvq8JvFw2k+m2UIXPjMgcCDnEcaDx88vdFLsgg==",
       "engines": {
-        "node": ">=12.0"
+        "node": ">=14.0"
       }
     },
     "node_modules/@humanwhocodes/config-array": {
@@ -17968,9 +17968,9 @@
       "dev": true
     },
     "@h4ad/dependency-extractor": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@h4ad/dependency-extractor/-/dependency-extractor-1.0.0.tgz",
-      "integrity": "sha512-2DbOyTWjxkS3F8ZBKfD1FwrKxsAnH9mOdRe9FD01Eldtx/DOwuGbvuSDh2BoAfc4FhdElf3a5RArzZExVfRMXA=="
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@h4ad/dependency-extractor/-/dependency-extractor-1.1.0.tgz",
+      "integrity": "sha512-kJdeQN4bKsWy5b5bAx7MW8q1yl+ZQmljF+HEateOZ5/B/MRyZvq8JvFw2k+m2UIXPjMgcCDnEcaDx88vdFLsgg=="
     },
     "@humanwhocodes/config-array": {
       "version": "0.9.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
         "@types/graceful-fs": "^4.1.5",
         "@types/mocha": "^9.0.0",
         "@types/mock-fs": "^4.13.1",
-        "@types/node": "12.20.43",
+        "@types/node": "14.18.34",
         "@types/plist": "^3.0.2",
         "@types/rimraf": "^3.0.2",
         "@types/terser": "^3.12.0",
@@ -72,7 +72,7 @@
         "unzipper": "^0.10.11"
       },
       "engines": {
-        "node": ">=12.0"
+        "node": ">=14.0"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -2154,9 +2154,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "12.20.43",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.43.tgz",
-      "integrity": "sha512-HCfJdaYqJX3BCzeihgZrD7b85Cu05OC/GVJ4kEYIflwUs4jbnUlLLWoq7hw1LBcdvUyehO+gr6P5JQ895/2ZfA==",
+      "version": "14.18.34",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.34.tgz",
+      "integrity": "sha512-hcU9AIQVHmPnmjRK+XUUYlILlr9pQrsqSrwov/JK1pnf3GTQowVBhx54FbvM0AU/VXGH4i3+vgXS5EguR7fysA==",
       "dev": true
     },
     "node_modules/@types/normalize-package-data": {
@@ -19135,9 +19135,9 @@
       }
     },
     "@types/node": {
-      "version": "12.20.43",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.43.tgz",
-      "integrity": "sha512-HCfJdaYqJX3BCzeihgZrD7b85Cu05OC/GVJ4kEYIflwUs4jbnUlLLWoq7hw1LBcdvUyehO+gr6P5JQ895/2ZfA==",
+      "version": "14.18.34",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.34.tgz",
+      "integrity": "sha512-hcU9AIQVHmPnmjRK+XUUYlILlr9pQrsqSrwov/JK1pnf3GTQowVBhx54FbvM0AU/VXGH4i3+vgXS5EguR7fysA==",
       "dev": true
     },
     "@types/normalize-package-data": {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "url": "https://github.com/H4ad"
   },
   "engines": {
-    "node": ">=12.0"
+    "node": ">=14.0"
   },
   "keywords": [
     "dependencies",
@@ -101,7 +101,7 @@
     "@types/graceful-fs": "^4.1.5",
     "@types/mocha": "^9.0.0",
     "@types/mock-fs": "^4.13.1",
-    "@types/node": "12.20.43",
+    "@types/node": "14.18.34",
     "@types/plist": "^3.0.2",
     "@types/rimraf": "^3.0.2",
     "@types/terser": "^3.12.0",

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     ]
   },
   "dependencies": {
-    "@h4ad/dependency-extractor": "^1.0.0",
+    "@h4ad/dependency-extractor": "1.1.0",
     "@oclif/core": "^1",
     "@oclif/plugin-autocomplete": "^1.3.0",
     "@oclif/plugin-commands": "^2.2.0",


### PR DESCRIPTION
<!--
  😀 Wonderful!  Thank you for opening a pull request.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.
-->

### Description of change

Bump depency-extrator to be able to process npm v9 lock file.

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `main` branch
- [x] `npm run lint` passes with this change
- [x] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [x] There are new or updated unit tests validating the change
- [ ] Added documentation inside `www/docs/main` folder.
- [ ] Included new files inside `index.doc.ts`.
- [x] The new commits follow conventions outlined in the [conventional commit spec](https://www.conventionalcommits.org/en/v1.0.0/)

<!--
  🎉 Thank you for contributing!
-->
